### PR TITLE
Add evidence labels to key documents (closes #22)

### DIFF
--- a/docs/evidence-labels.md
+++ b/docs/evidence-labels.md
@@ -1,0 +1,69 @@
+# Evidence Labels
+
+This project mixes Banks source material, interpretation, original design decisions, and speculative ideas. To make the distinction visible, key claims throughout the documentation are tagged with one of four evidence labels.
+
+---
+
+## The four labels
+
+### `[canonical]`
+Directly supported by Banks source text (*A Few Notes on Marain*, the Culture novels, or explicit authorial statements). The claim can be traced to a specific passage.
+
+**Example:** Marain has a single gender-neutral third-person pronoun. Banks states this explicitly.
+
+---
+
+### `[inference]`
+Consistent with canonical source material, but not explicitly stated. The claim follows logically from what Banks wrote, but Banks did not write it in so many words.
+
+**Example:** Marain was designed primarily for transmission rather than inscription. The source supports binary efficiency and tightbeam transmission, but does not explicitly call the written form a "debug view."
+
+---
+
+### `[project decision]`
+A deliberate design choice made by marainkit where the canonical source is silent or ambiguous. The decision is ours to make; we have made it; it is documented.
+
+**Example:** The 8 invariant glyphs are reserved for structural and warning vocabulary. Banks defines their geometry; the reservation policy is our decision.
+
+---
+
+### `[speculative]`
+An interesting idea or design hypothesis that is not yet grounded in evidence, testing, or implementation. Worth pursuing, but should not be treated as a proven property of the system.
+
+**Example:** The claim that a fixed specification "largely solves" long-term meaning drift. Plausible, but untested.
+
+---
+
+## How labels are used
+
+Labels appear inline in documents, in bold brackets, attached to a specific claim or section heading:
+
+```
+**[canonical]** Banks states that Marain has a gender-neutral third-person pronoun.
+
+**[inference]** The written script is downstream of the binary signal.
+
+**[project decision]** Invariant glyphs are reserved for structural and warning use.
+
+**[speculative]** A fixed specification largely solves long-term meaning drift.
+```
+
+Where an entire section carries a single evidence level, the label appears in the section heading:
+
+```
+### Longevity of meaning `[speculative]`
+```
+
+Where a section contains claims of mixed status, individual sentences are labelled.
+
+---
+
+## Why this matters
+
+The repo has real technical substance. Muddling its epistemic levels — treating inference as canon, or speculation as engineering requirement — undermines the credibility of the parts that *are* solid. Labels make the distinction visible without removing the ideas.
+
+A reader encountering a `[speculative]` label should understand: *this is an interesting hypothesis worth testing, not a property the system has already demonstrated.*
+
+---
+
+*See also:* [`rationale.md`](rationale.md), [`sapir-whorf.md`](sapir-whorf.md), [`layers.md`](layers.md) — documents where labels are applied.

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -1,18 +1,28 @@
 # Marain as a Four-Layer System
 
+> **Evidence labels used in this document:**
+> `[canonical]` — directly from Banks source text ·
+> `[inference]` — consistent with canon, not explicitly stated ·
+> `[project decision]` — deliberate choice where canon is silent ·
+> `[speculative]` — interesting hypothesis, not yet tested
+>
+> *See [evidence-labels.md](evidence-labels.md) for full definitions.*
+
 ---
 
 ## The Native Medium: Tightbeam Laser
 
-The most important reframing: **Marain was designed for transmission, not inscription.**
+The most important reframing: **[inference]** Marain was designed for transmission, not inscription.
 
-A tightbeam laser carries a binary bitstream across interstellar space. The 3×3 glyph system is what you get when you *render* that bitstream for human eyes. The script is downstream of the signal.
+The source supports: binary encoding mattered to Banks; tightbeam transmission is canonical; the buffer bit and extended packet structure imply a transmission-oriented design. What the source does not explicitly state: that the written script is a rendering of a transmission-first signal, or that inscription is secondary.
 
-This means:
-- Binary encoding is **canonical**, not a simplification
-- Human-readable glyphs are essentially a **debug view** of the transmission
-- GCU Grey Area is correctly understood as a **renderer**, not a writing system
-- Tone and emotional content baked into the bitstream means affect is **propositional**, not performative
+**[canonical]** A tightbeam laser carries a binary bitstream across interstellar space. **[inference]** The 3×3 glyph system is what you get when you *render* that bitstream for human eyes — the script is downstream of the signal. This is a project interpretation, consistent with canon but not directly stated.
+
+This interpretation implies:
+- **[canonical]** Binary encoding is the substrate — not a simplification
+- **[inference]** Human-readable glyphs are essentially a **debug view** of the transmission
+- **[project decision]** GCU Grey Area is correctly understood as a **renderer**, not a writing system
+- **[inference]** Tone and emotional content baked into the bitstream means affect is **propositional**, not performative
 
 ---
 

--- a/docs/rationale.md
+++ b/docs/rationale.md
@@ -2,6 +2,14 @@
 
 *Stub. This document captures the motivations behind marainkit. To be expanded in future sessions.*
 
+> **Evidence labels used in this document:**
+> `[canonical]` — directly from Banks source text ·
+> `[inference]` — consistent with canon, not explicitly stated ·
+> `[project decision]` — deliberate choice where canon is silent ·
+> `[speculative]` — interesting hypothesis, not yet tested
+>
+> *See [evidence-labels.md](evidence-labels.md) for full definitions.*
+
 ---
 
 ## The core argument
@@ -12,32 +20,32 @@ A constructed language with a deterministic, binary-encoded writing system offer
 
 ## Benefits — stub list
 
-### Semantic specificity
-Natural languages are ambiguous by design — context, tone, and shared culture fill the gaps. A constructed language can define meanings precisely and permanently, eliminating the classes of misunderstanding that cause harm at scale: legal ambiguity, medical miscommunication, diplomatic misreading.
+### Semantic specificity `[speculative]`
+Natural languages are ambiguous by design — context, tone, and shared culture fill the gaps. A constructed language can define meanings more precisely and permanently than a natural one. **[speculative]** Whether this eliminates the classes of misunderstanding that cause harm at scale — legal ambiguity, medical miscommunication, diplomatic misreading — is a design hypothesis, not a demonstrated property.
 
-### Equality of access to knowledge
-A script that is learned rather than inherited does not belong to any culture, nation, or economic class. A child in any location, with any native language, encounters it on equal terms. Knowledge encoded in Marain is not gated by which language you were born into.
+### Equality of access to knowledge `[project decision]` `[speculative]`
+**[project decision]** A script that is learned rather than inherited is a design goal of marainkit — it should not belong to any culture, nation, or economic class. **[speculative]** Whether a child in any location encounters it on genuinely equal terms depends on adoption, tooling, and pedagogy that do not yet exist. The aspiration is real; the outcome is not yet established.
 
-### Universalism
-No natural writing system is neutral. Every existing script carries the history and power structures of the civilisation that produced it. A constructed system, designed openly and transparently, can be genuinely universal — owned by no one, available to everyone.
+### Universalism `[speculative]`
+No natural writing system is neutral. Every existing script carries the history and power structures of the civilisation that produced it. **[speculative]** Whether a constructed system, designed openly and transparently, can be *genuinely* universal — owned by no one, available to everyone — is a research question, not a proven outcome. The goal is worth pursuing; the claim requires evidence.
 
-### Alignment with AI systems
-Binary-encoded, deterministic, semantically precise language is the natural interface layer between human meaning and machine processing. A Marain encoding layer eliminates the lossy translation step between human intent and machine representation. As AI systems become more embedded in daily life, a shared formal language reduces the surface area for misinterpretation.
+### Alignment with AI systems `[speculative]`
+**[speculative]** Binary-encoded, deterministic, semantically precise language *may* reduce the surface area for misinterpretation between human intent and machine processing. The claim that it "eliminates the lossy translation step" is a hypothesis. The relationship between Marain's encoding model and AI system design has not been tested.
 
-### Hardware efficiency
-A 9-bit grid with 512 states maps cleanly onto binary memory structures. Marain text is compact, self-describing, and does not require complex Unicode normalisation, bidirectional rendering, or font fallback chains. It is maximally efficient on constrained hardware — embedded systems, low-power devices, transmission over degraded channels.
+### Hardware efficiency `[project decision]`
+**[project decision]** A 9-bit grid with 512 states maps cleanly onto binary memory structures. Marain text is compact, self-describing, and does not require complex Unicode normalisation, bidirectional rendering, or font fallback chains. These are architectural properties of the design — verifiable in principle, though not yet benchmarked against real targets.
 
-### Deep history encoding — substrate independence
-Information encoded in Marain does not require functioning software, a power grid, or institutional continuity to be read. The encoding is geometric and binary — it can be carved, stamped, woven, printed, or transmitted as radio pulses. A civilisation that loses its infrastructure can still read Marain from a physical surface. This is not true of any digital-native format.
+### Deep history encoding — substrate independence `[project decision]` `[speculative]`
+**[project decision]** The encoding is geometric and binary — it can be carved, stamped, woven, printed, or transmitted as radio pulses. This substrate independence is a deliberate design property. **[speculative]** The claim that "a civilisation that loses its infrastructure can still read Marain from a physical surface" while no digital-native format survives is a thought experiment, not a tested scenario.
 
-### Resilience and redundancy
-The 8 rotation/mirror-invariant glyphs provide orientation markers that survive physical degradation, partial destruction, and arbitrary rotation. A fragment of Marain text can be identified and oriented without context. No natural script has this property.
+### Resilience and redundancy `[canonical]` `[project decision]`
+**[canonical]** The 8 rotation/mirror-invariant glyphs emerge from the geometry of the 3×3 binary grid — they are a mathematical property of the system, not an invention. **[project decision]** The decision to reserve these as orientation markers — to exploit their orientation-invariance for orientation recovery — is marainkit's choice. Banks does not specify this use.
 
-### Inclusion across ability
-A system designed from first principles can accommodate non-standard interaction: tactile (raised dots), auditory (tonal encoding), visual (high-contrast binary glyphs). Accessibility is architectural, not retrofitted.
+### Inclusion across ability `[project decision]`
+**[project decision]** A system designed from first principles can accommodate non-standard interaction: tactile (raised dots), auditory (tonal encoding), visual (high-contrast binary glyphs). This is a design goal, not a property the system has demonstrated. Accessibility is an architectural aspiration; whether it has been achieved requires implementation and testing.
 
-### Longevity of meaning
-Natural language drift makes texts opaque within centuries. A constructed language with a fixed, published specification does not drift unless intentionally updated. Meanings encoded today remain legible to a reader in 500 years who has access only to the specification.
+### Longevity of meaning `[speculative]`
+**[speculative]** The claim that a fixed, published specification prevents meaning drift is plausible — natural languages do drift and constructed ones with stable specs may drift less — but it is untested at the timescales claimed. A reader in 500 years with access only to the specification is a thought experiment, not a validated scenario.
 
 ---
 
@@ -49,7 +57,7 @@ Natural language drift makes texts opaque within centuries. A constructed langua
 
 ### The model
 
-The dictionary maps **Marain → concept**, not **Marain → English word**. Translations are derived at query time from an external concept graph, not stored locally. This keeps the dictionary lean, substrate-independent, and language-neutral by default.
+**[project decision]** The dictionary maps **Marain → concept**, not **Marain → English word**. Translations are derived at query time from an external concept graph, not stored locally. This keeps the dictionary lean, substrate-independent, and language-neutral by default.
 
 ```
 Marain glyph / word  →  concept ID  →  translation in any language (on demand)

--- a/docs/sapir-whorf.md
+++ b/docs/sapir-whorf.md
@@ -2,6 +2,14 @@
 
 > Cross-cutting spec. Relates to all layers of the four-layer model. See also [`rationale.md`](rationale.md) for the broader project philosophy.
 
+> **Evidence labels used in this document:**
+> `[canonical]` — directly from Banks source text ·
+> `[inference]` — consistent with canon, not explicitly stated ·
+> `[project decision]` — deliberate choice where canon is silent ·
+> `[speculative]` — interesting hypothesis, not yet tested
+>
+> *See [evidence-labels.md](evidence-labels.md) for full definitions.*
+
 ---
 
 ## 1. The Hypothesis
@@ -36,25 +44,27 @@ This is precisely what a *design system* does.
 
 ## 2. Banks and Marain
 
-Banks was explicit: the Culture's Minds designed Marain to exploit linguistic relativity as social engineering. From *"A Few Notes on Marain"* and the novels, the design goals are:
+**[canonical]** Banks was explicit that the Culture's Minds designed Marain with deliberate social engineering goals. From *"A Few Notes on Marain"* and the novels, several design properties are stated or strongly implied. The table below distinguishes what the source directly supports from what is project interpretation:
 
-| Goal | Linguistic mechanism |
-|------|---------------------|
-| Egalitarianism | Single gender-neutral third-person pronoun eliminates gendered default framing |
-| Non-hierarchy | Grammar that avoids encoding dominance relationships as structural defaults |
-| Reduced ambiguity | Engineered phoneme set and tonal system create sharper category boundaries |
-| Universality | Orientation-invariant glyphs remove privileged reading direction — no culture's spatial habits are canonical |
-| Transparency | Tightbeam-native binary encoding means the signal *is* the meaning — no hidden layers between transmission and semantics |
+| Goal | Linguistic mechanism | Status |
+|------|---------------------|--------|
+| Egalitarianism | Single gender-neutral third-person pronoun eliminates gendered default framing | **[canonical]** — Banks states this explicitly |
+| Non-hierarchy | Grammar that avoids encoding dominance relationships as structural defaults | **[inference]** — consistent with Banks' framing, not explicitly specified |
+| Reduced ambiguity | Engineered phoneme set and tonal system create sharper category boundaries | **[inference]** — implied by the designed nature of the system |
+| Universality | Orientation-invariant glyphs remove privileged reading direction | **[inference]** — the geometry is canonical; this interpretation of its purpose is ours |
+| Transparency | Tightbeam-native binary encoding means the signal *is* the meaning | **[inference]** — see note below |
 
-Banks understood the weak version intuitively: you don't need language to *prevent* hierarchical thinking — you just need it to stop *making hierarchy the path of least resistance*. If your pronoun system doesn't sort people by gender, you can still *notice* gender, but you have to spend cognitive effort to do it. The default shifts.
+**Note on "Transparency":** The claim that Marain was designed primarily for transmission, making the written form downstream of the signal, is a project interpretation. The source supports binary efficiency and tightbeam transmission; it does not explicitly describe the written script as a "debug view." This inference is labelled separately in [`layers.md`](layers.md).
+
+**[canonical]** Banks understood the weak Sapir-Whorf version intuitively: you don't need language to *prevent* hierarchical thinking — you just need it to stop *making hierarchy the path of least resistance*. If your pronoun system doesn't sort people by gender, you can still *notice* gender, but you have to spend cognitive effort to do it. The default shifts.
 
 This is the deepest alignment between Banks' fiction and the Sapir-Whorf evidence: **engineered defaults, not engineered constraints.**
 
 ---
 
-## 3. Where marainkit Already Embodies Sapir-Whorf
+## 3. Where marainkit Already Embodies Sapir-Whorf `[project decision]`
 
-Several design decisions we've already made are Sapir-Whorf mechanisms, whether or not we named them as such:
+Several design decisions we've already made are Sapir-Whorf mechanisms, whether or not we named them as such. The claims in this section describe deliberate marainkit design choices — not properties canonical Marain has been demonstrated to have.
 
 ### 3.1 Invariant glyphs as categorical perception
 
@@ -86,7 +96,7 @@ This prevents the common failure mode of designing for an implicit default conte
 
 ---
 
-## 4. Actionable Implications
+## 4. Actionable Implications `[project decision]`
 
 ### 4.1 Token naming is category creation
 
@@ -138,7 +148,7 @@ Column B (phoneme composition with tonal encoding) is where the Sapir-Whorf impl
 
 ---
 
-## 5. The Meta-Point
+## 5. The Meta-Point `[speculative]`
 
 The deepest implication of Sapir-Whorf for marainkit is this: **we are not just building a display system. We are building a representational system that will shape how its users perceive information.**
 


### PR DESCRIPTION
Creates docs/evidence-labels.md defining four label types:
[canonical], [inference], [project decision], [speculative].

Applies labels throughout the three priority documents identified
in the issue: rationale.md, sapir-whorf.md, and layers.md.

Key clarifications made visible:
- rationale.md benefits section: universalism, AI alignment,
  longevity of meaning, and equality claims marked [speculative];
  hardware efficiency and resilience marked appropriately
- sapir-whorf.md §2: the Banks/Marain table now distinguishes
  what the source states from project interpretation; §3–5
  marked as [project decision] and [speculative] respectively
- layers.md: the transmission-first claim marked [inference]
  with an explicit note that it is not directly stated in source

https://claude.ai/code/session_01RWWCQK4kb9m6H1EMfoqB7K